### PR TITLE
fix(pkg/kubectl-debug/cmd): fix incorrect code

### DIFF
--- a/cmd/debug-agent/main.go
+++ b/cmd/debug-agent/main.go
@@ -2,8 +2,8 @@ package main
 
 import (
 	"flag"
-	"log"
 	"github.com/jamestgrant/kubectl-debug/pkg/debug-agent"
+	"log"
 )
 
 func main() {

--- a/pkg/debug-agent/config.go
+++ b/pkg/debug-agent/config.go
@@ -2,9 +2,9 @@ package debugagent
 
 import (
 	"fmt"
+	"gopkg.in/yaml.v2"
 	"io/ioutil"
 	"time"
-	"gopkg.in/yaml.v2"
 )
 
 var (
@@ -14,23 +14,23 @@ var (
 		RuntimeTimeout:        30 * time.Second,
 		StreamIdleTimeout:     10 * time.Minute,
 		StreamCreationTimeout: 15 * time.Second,
-		ListenAddress: "0.0.0.0:10027",
-		AuditFifo: "/var/data/kubectl-debug-audit-fifo/KCTLDBG-CONTAINER-ID",
-		AuditShim: []string{"/usr/bin/strace", "-o", "KCTLDBG-FIFO", "-f", "-e", "trace=/exec"},
+		ListenAddress:         "0.0.0.0:10027",
+		AuditFifo:             "/var/data/kubectl-debug-audit-fifo/KCTLDBG-CONTAINER-ID",
+		AuditShim:             []string{"/usr/bin/strace", "-o", "KCTLDBG-FIFO", "-f", "-e", "trace=/exec"},
 	}
 )
 
 type Config struct {
-	DockerEndpoint        	string			`yaml:"docker_endpoint,omitempty"`
-	ContainerdEndpoint    	string       	`yaml:"containerd_endpoint,omitempty"`
-	RuntimeTimeout        	time.Duration 	`yaml:"runtime_timeout,omitempty"`
-	StreamIdleTimeout     	time.Duration 	`yaml:"stream_idle_timeout,omitempty"`
-	StreamCreationTimeout 	time.Duration 	`yaml:"stream_creation_timeout,omitempty"`
-	ListenAddress 			string 		  	`yaml:"listen_address,omitempty"`
-	Verbosity     			int    			`yaml:"verbosity,omitempty"`
-	Audit     				bool     		`yaml:"audit,omitempty"`
-	AuditFifo 				string   		`yaml:"audit_fifo,omitempty"`
-	AuditShim 				[]string 		`yaml:"audit_shim,omitempty"`
+	DockerEndpoint        string        `yaml:"docker_endpoint,omitempty"`
+	ContainerdEndpoint    string        `yaml:"containerd_endpoint,omitempty"`
+	RuntimeTimeout        time.Duration `yaml:"runtime_timeout,omitempty"`
+	StreamIdleTimeout     time.Duration `yaml:"stream_idle_timeout,omitempty"`
+	StreamCreationTimeout time.Duration `yaml:"stream_creation_timeout,omitempty"`
+	ListenAddress         string        `yaml:"listen_address,omitempty"`
+	Verbosity             int           `yaml:"verbosity,omitempty"`
+	Audit                 bool          `yaml:"audit,omitempty"`
+	AuditFifo             string        `yaml:"audit_fifo,omitempty"`
+	AuditShim             []string      `yaml:"audit_shim,omitempty"`
 }
 
 func Load(s string) (*Config, error) {

--- a/pkg/debug-agent/runtime.go
+++ b/pkg/debug-agent/runtime.go
@@ -22,8 +22,6 @@ import (
 	"text/tabwriter"
 	"time"
 
-	"github.com/jamestgrant/kubectl-debug/pkg/nsenter"
-	term "github.com/jamestgrant/kubectl-debug/pkg/util"
 	containerd "github.com/containerd/containerd"
 	"github.com/containerd/containerd/cio"
 	"github.com/containerd/containerd/content"
@@ -41,6 +39,8 @@ import (
 	dockerclient "github.com/docker/docker/client"
 	"github.com/docker/docker/pkg/stdcopy"
 	"github.com/google/uuid"
+	"github.com/jamestgrant/kubectl-debug/pkg/nsenter"
+	term "github.com/jamestgrant/kubectl-debug/pkg/util"
 	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/opencontainers/runtime-spec/specs-go"

--- a/pkg/kubectl-debug/config.go
+++ b/pkg/kubectl-debug/config.go
@@ -1,8 +1,8 @@
 package kubectldebug
 
 import (
-	"io/ioutil"
 	"gopkg.in/yaml.v2"
+	"io/ioutil"
 )
 
 type Config struct {

--- a/pkg/util/resizeevents.go
+++ b/pkg/util/resizeevents.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 /*


### PR DESCRIPTION
fix some error.

pkg/kubectl-debug/cmd line: 698, extra back parentheses
pkg/kubectl-debug/cmd line: 1160,  the variable's name should be  opts
pkg/kubectl-debug/cmd line: 1166, the variable's name should be  opts